### PR TITLE
Add logging

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,9 +22,12 @@ func getListenAddress() string {
 	return fmt.Sprintf("%v:%d", *address, *port)
 }
 
+var l *log.Logger
+
 func main() {
 	listenAddress := getListenAddress()
-	log.Println("Starting cloudinary-exporter")
+	l := log.New(os.Stderr, "", 1)
+	l.Println("Starting cloudinary-exporter")
 
 	err := cloudinary.NewCredentials(
 		os.Getenv("CLOUDINARY_CLOUD_NAME"),
@@ -32,17 +35,17 @@ func main() {
 		os.Getenv("CLOUDINARY_SECRET"),
 	)
 	if err != nil {
-		log.Fatal(err)
+		l.Fatal(err)
 	}
 
-	exporter, err := exporter.NewExporter()
+	exporter, err := exporter.NewExporter(l)
 	if err != nil {
-		log.Fatal(err)
+		l.Fatal(err)
 	}
 
 	prometheus.MustRegister(exporter)
 
-	log.Println("Listening on", listenAddress)
+	l.Println("Listening on", listenAddress)
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`<html>
@@ -53,5 +56,5 @@ func main() {
                 </body>
                 </html>`))
 	})
-	log.Fatal(http.ListenAndServe(listenAddress, nil))
+	l.Fatal(http.ListenAndServe(listenAddress, nil))
 }

--- a/main.go
+++ b/main.go
@@ -22,8 +22,6 @@ func getListenAddress() string {
 	return fmt.Sprintf("%v:%d", *address, *port)
 }
 
-var l *log.Logger
-
 func main() {
 	listenAddress := getListenAddress()
 	l := log.New(os.Stderr, "", 1)

--- a/pkg/cloudinary/usage_report.go
+++ b/pkg/cloudinary/usage_report.go
@@ -48,7 +48,10 @@ func GetUsageReport(req *http.Request) (usageReport *UsageReport, err error) {
 	client := http.Client{}
 	rs, err := client.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf(
+			"ERROR: Request failure: %v",
+			err,
+		)
 	}
 	defer rs.Body.Close()
 

--- a/pkg/cloudinary/usage_report.go
+++ b/pkg/cloudinary/usage_report.go
@@ -55,7 +55,7 @@ func GetUsageReport(req *http.Request) (usageReport *UsageReport, err error) {
 	}
 	defer rs.Body.Close()
 
-	if rs.StatusCode != 200 {
+	if rs.StatusCode != 200 && rs.StatusCode != 201 {
 		return nil, fmt.Errorf(
 			"ERROR: Cloudinary API complained: %v",
 			rs.Header.Get("X-Cld-Error"),

--- a/pkg/cloudinary/usage_report.go
+++ b/pkg/cloudinary/usage_report.go
@@ -52,6 +52,12 @@ func GetUsageReport(req *http.Request) (usageReport *UsageReport, err error) {
 	}
 	defer rs.Body.Close()
 
+	if rs.StatusCode != 200 {
+		return nil, fmt.Errorf(
+			"ERROR: Cloudinary API complained: %v",
+			rs.Header.Get("X-Cld-Error"),
+		)
+	}
 	bodyBytes, err := ioutil.ReadAll(rs.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Add logging of failed requests
    These failures can be because of network problems, and other issues
    happening under HTTP.

* Add logging of Cloudinary API errors
    This logs errors reported by the Cloudinary API itself.

* Add basic logging features
    In `main.go`, logger can be a global variable, so any function could be
    using it without need to pass it as parameter.
    In `explorer.go`, logger is required to log requests operations, since it's
    not happening in the main thread. In case nil is passed, it will create a
    default `log.Logger`.

Refs and fixes #4